### PR TITLE
MacOS standard settings window. Fix issue#39

### DIFF
--- a/rem/remApp.swift
+++ b/rem/remApp.swift
@@ -31,7 +31,7 @@ struct remApp: App {
 
     var body: some Scene {
         // Empty scene, as we are controlling everything through the AppDelegate
-        Settings { EmptyView() }
+        Settings { SettingsView(settingsManager: appDelegate.settingsManager) }
     }
 }
 
@@ -189,7 +189,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             menu.addItem(
                 withTitle: "Settings",
                 action: #selector(self.openSettings),
-                keyEquivalent: ""
+                keyEquivalent: ","
             )
             menu.addItem(NSMenuItem(title: "Quit", action: #selector(self.quitApp), keyEquivalent: "q"))
             self.statusBarItem.menu = menu


### PR DESCRIPTION
This PR fixes #39  by letting the user open the settings window when pressing `cmd + ,`

It also adds a keyEquivalent to the menu. 
<img width="208" alt="Capture d’écran 2023-12-31 à 14 48 56" src="https://github.com/jasonjmcghee/rem/assets/55260356/6de3fc74-b9ac-4010-8af7-0512efd54470">
