### PR TITLE
Update to use our forked SQLite.swift

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "SQLite.swift"]
 	path = SQLite.swift
-	url = https://github.com/stephencelis/SQLite.swift
-	branch = master
+	url = https://github.com/jasonjmcghee/SQLite.swift
+	branch = main

--- a/README.md
+++ b/README.md
@@ -56,7 +56,6 @@ Also, that means there is no tracking / analytics of any kind, which means I don
 
 - Clone the repo `git clone --recursive -j8 https://github.com/jasonjmcghee/rem.git` or run `git submodule update --init --recursive` after cloning
 - Open project in Xcode
-- Change default SQLite.Swift sdk architecture to macOS <img width="1512" alt="Screenshot 2023-12-28 at 5 38 19 PM" src="https://github.com/ruslanjabari/rem/assets/59275080/63c08975-0bd2-4fe8-91ca-0b9406d44704">
 - Product > Archive
 - Distribute App
 - Custom


### PR DESCRIPTION
Now that we're using our forked version, it should _just work_ rather than needing to manually update the target to macos.