### PR TITLE
Timeline Fullscreen Without Ext Monitor Blackouts

### DIFF
--- a/rem/TimelineView.swift
+++ b/rem/TimelineView.swift
@@ -177,7 +177,7 @@ class CustomHostingViewController: NSViewController {
             self.view.window?.makeKey()
         }
     }
-    
+
     override func loadView() {
         let _interceptingView = CustomInterceptingView()
         _interceptingView.onClose = onClose

--- a/rem/TimelineView.swift
+++ b/rem/TimelineView.swift
@@ -177,7 +177,7 @@ class CustomHostingViewController: NSViewController {
             self.view.window?.makeKey()
         }
     }
-
+    
     override func loadView() {
         let _interceptingView = CustomInterceptingView()
         _interceptingView.onClose = onClose
@@ -190,6 +190,13 @@ class CustomHostingViewController: NSViewController {
         }
         _interceptingView.customHostingView = customHostingView
         interceptingView = _interceptingView
+        
+        NSAnimationContext.runAnimationGroup({ context in
+                    context.duration = 0.0 // Setting duration to zero effectively disables animations
+                    self.view.window?.toggleFullScreen(nil)
+                }, completionHandler: {
+                    // Any additional code after animation completes
+                })
     }
 
     func updateImage(_ image: NSImage, frame: NSRect) {
@@ -206,6 +213,12 @@ class CustomHostingViewController: NSViewController {
 
     func updateContent(image: NSImage?, frame: NSRect, analysis: ImageAnalysis?) {
         if let im = image {
+            let fullScreenOptions = [NSView.FullScreenModeOptionKey.fullScreenModeAllScreens: NSNumber(value: false)]
+            if !view.isInFullScreenMode {
+                DispatchQueue.main.async {
+                    self.view.enterFullScreenMode(NSScreen.main!, withOptions: fullScreenOptions)
+                }
+            }
             updateImage(im, frame: frame)
             updateAnalysis(analysis)
             hadImage = true

--- a/rem/TimelineView.swift
+++ b/rem/TimelineView.swift
@@ -190,13 +190,6 @@ class CustomHostingViewController: NSViewController {
         }
         _interceptingView.customHostingView = customHostingView
         interceptingView = _interceptingView
-        
-        NSAnimationContext.runAnimationGroup({ context in
-                    context.duration = 0.0 // Setting duration to zero effectively disables animations
-                    self.view.window?.toggleFullScreen(nil)
-                }, completionHandler: {
-                    // Any additional code after animation completes
-                })
     }
 
     func updateImage(_ image: NSImage, frame: NSRect) {

--- a/rem/TimelineView.swift
+++ b/rem/TimelineView.swift
@@ -177,6 +177,15 @@ class CustomHostingViewController: NSViewController {
             self.view.window?.makeKey()
         }
     }
+    
+    override func viewDidAppear() {
+        super.viewDidAppear()
+        guard let window = view.window else { return }
+        
+        if !self.view.isInFullScreenMode{
+            window.toggleFullScreen(nil)
+        }
+    }
 
     override func loadView() {
         let _interceptingView = CustomInterceptingView()
@@ -206,11 +215,6 @@ class CustomHostingViewController: NSViewController {
 
     func updateContent(image: NSImage?, frame: NSRect, analysis: ImageAnalysis?) {
         if let im = image {
-            if !view.isInFullScreenMode {
-                DispatchQueue.main.async {
-                    self.view.enterFullScreenMode(NSScreen.main!)
-                }
-            }
             updateImage(im, frame: frame)
             updateAnalysis(analysis)
             hadImage = true

--- a/rem/TimelineView.swift
+++ b/rem/TimelineView.swift
@@ -30,10 +30,11 @@ struct TimelineView: View {
         _customHostingView = State(initialValue: nil)
     }
     
+    
     var body: some View {
         ZStack {
             let frame = NSScreen.main?.frame ?? NSRect.zero
-            let image = DatabaseManager.shared.getImage(index: viewModel.currentFrameIndex)
+            let image = viewModel.getNextImage()
             let nsImage = image.flatMap { NSImage(cgImage: $0, size: NSSize(width: $0.width, height: $0.height)) }
             
             CustomHostingControllerRepresentable(
@@ -321,6 +322,15 @@ class TimelineViewModel: ObservableObject {
             self.currentFrameContinuous = Double(maxFrame)
             self.currentFrameIndex = maxFrame
         }
+    }
+    
+    func getNextImage() -> CGImage? {
+        var image = DatabaseManager.shared.getImage(index: self.currentFrameIndex)
+        while image == nil {
+            self.updateIndex(withDelta: 1)
+            image = DatabaseManager.shared.getImage(index: self.currentFrameIndex)
+        }
+        return image
     }
     
     func updateIndexSafely() {

--- a/rem/TimelineView.swift
+++ b/rem/TimelineView.swift
@@ -30,7 +30,6 @@ struct TimelineView: View {
         _customHostingView = State(initialValue: nil)
     }
     
-    
     var body: some View {
         ZStack {
             let frame = NSScreen.main?.frame ?? NSRect.zero
@@ -55,13 +54,13 @@ struct TimelineView: View {
                 }
             
             if image == nil {
-                    VStack(alignment: .center) {
-                        Text("Nothing to remember, or missing frame (if missing, sorry, still alpha!)")
-                            .padding()
-                            .background(RoundedRectangle(cornerRadius: 10)
-                                .fill(Color.white.opacity(0.1)))
-                    }
+                VStack(alignment: .center) {
+                    Text("Nothing to remember, or missing frame (if missing, sorry, still alpha!)")
+                        .padding()
+                        .background(RoundedRectangle(cornerRadius: 10)
+                            .fill(Color.white.opacity(0.1)))
                 }
+            }
             
         }
         .ignoresSafeArea(.all)

--- a/rem/TimelineView.swift
+++ b/rem/TimelineView.swift
@@ -34,7 +34,7 @@ struct TimelineView: View {
     var body: some View {
         ZStack {
             let frame = NSScreen.main?.frame ?? NSRect.zero
-            let image = viewModel.getNextImage()
+            let image = DatabaseManager.shared.getImage(index: viewModel.currentFrameIndex)
             let nsImage = image.flatMap { NSImage(cgImage: $0, size: NSSize(width: $0.width, height: $0.height)) }
             
             CustomHostingControllerRepresentable(
@@ -55,13 +55,13 @@ struct TimelineView: View {
                 }
             
             if image == nil {
-                VStack(alignment: .center) {
-                    Text("Nothing to remember, or missing frame (if missing, sorry, still alpha!)")
-                        .padding()
-                        .background(RoundedRectangle(cornerRadius: 10)
-                            .fill(Color.white.opacity(0.1)))
+                    VStack(alignment: .center) {
+                        Text("Nothing to remember, or missing frame (if missing, sorry, still alpha!)")
+                            .padding()
+                            .background(RoundedRectangle(cornerRadius: 10)
+                                .fill(Color.white.opacity(0.1)))
+                    }
                 }
-            }
             
         }
         .ignoresSafeArea(.all)
@@ -176,15 +176,6 @@ class CustomHostingViewController: NSViewController {
     override func viewWillAppear() {
         DispatchQueue.main.async {
             self.view.window?.makeKey()
-        }
-    }
-    
-    override func viewDidAppear() {
-        super.viewDidAppear()
-        guard let window = view.window else { return }
-        
-        if !self.view.isInFullScreenMode{
-            window.toggleFullScreen(nil)
         }
     }
 
@@ -322,15 +313,6 @@ class TimelineViewModel: ObservableObject {
             self.currentFrameContinuous = Double(maxFrame)
             self.currentFrameIndex = maxFrame
         }
-    }
-    
-    func getNextImage() -> CGImage? {
-        var image = DatabaseManager.shared.getImage(index: self.currentFrameIndex)
-        while image == nil {
-            self.updateIndex(withDelta: 1)
-            image = DatabaseManager.shared.getImage(index: self.currentFrameIndex)
-        }
-        return image
     }
     
     func updateIndexSafely() {

--- a/rem/remApp.swift
+++ b/rem/remApp.swift
@@ -649,10 +649,11 @@ func drawStatusBarIcon(rect: CGRect) -> Bool {
             let screenRect = NSScreen.main?.frame ?? NSRect.zero
             timelineViewWindow = MainWindow(
                 contentRect: screenRect,
-                styleMask: [.borderless, .titled, .closable, .miniaturizable, .resizable, .fullSizeContentView],
+                styleMask: [.borderless, .fullSizeContentView],
                 backing: .buffered,
                 defer: false
             )
+            
             timelineViewWindow?.hasShadow = false
             timelineViewWindow?.level = .normal
 
@@ -664,6 +665,7 @@ func drawStatusBarIcon(rect: CGRect) -> Bool {
                 }
             })
             timelineView?.viewModel.updateIndex(withIndex: index)
+            timelineViewWindow?.toggleFullScreen(nil)
 
             timelineViewWindow?.contentView = NSHostingView(rootView: timelineView)
             timelineView?.viewModel.setIsOpen(isOpen: true)
@@ -672,6 +674,7 @@ func drawStatusBarIcon(rect: CGRect) -> Bool {
                 self.timelineViewWindow?.orderFrontRegardless() // Ensure it comes to the front
             }
         } else if !isTimelineOpen() {
+            timelineViewWindow?.toggleFullScreen(nil)
             timelineView?.viewModel.updateIndex(withIndex: index)
             timelineView?.viewModel.setIsOpen(isOpen: true)
             timelineViewWindow?.makeKeyAndOrderFront(nil)

--- a/rem/remApp.swift
+++ b/rem/remApp.swift
@@ -649,7 +649,7 @@ func drawStatusBarIcon(rect: CGRect) -> Bool {
             let screenRect = NSScreen.main?.frame ?? NSRect.zero
             timelineViewWindow = MainWindow(
                 contentRect: screenRect,
-                styleMask: [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView],
+                styleMask: [.borderless, .titled, .closable, .miniaturizable, .resizable, .fullSizeContentView],
                 backing: .buffered,
                 defer: false
             )

--- a/rem/remApp.swift
+++ b/rem/remApp.swift
@@ -656,7 +656,7 @@ func drawStatusBarIcon(rect: CGRect) -> Bool {
             timelineViewWindow?.hasShadow = false
             timelineViewWindow?.level = .normal
 
-            timelineViewWindow?.collectionBehavior = [.fullScreenPrimary, .canJoinAllSpaces, .participatesInCycle]
+            timelineViewWindow?.collectionBehavior = [.fullScreenAuxiliary, .canJoinAllSpaces, .participatesInCycle]
             timelineViewWindow?.ignoresMouseEvents = false
             timelineView = TimelineView(viewModel: TimelineViewModel(), settingsManager: settingsManager, onClose: {
                 DispatchQueue.main.async { [weak self] in
@@ -664,10 +664,9 @@ func drawStatusBarIcon(rect: CGRect) -> Bool {
                 }
             })
             timelineView?.viewModel.updateIndex(withIndex: index)
-
+            
             timelineViewWindow?.contentView = NSHostingView(rootView: timelineView)
             timelineView?.viewModel.setIsOpen(isOpen: true)
-            self.timelineViewWindow?.toggleFullScreen(nil)
             timelineViewWindow?.makeKeyAndOrderFront(nil)
             DispatchQueue.main.async {
                 self.timelineViewWindow?.orderFrontRegardless() // Ensure it comes to the front
@@ -675,7 +674,6 @@ func drawStatusBarIcon(rect: CGRect) -> Bool {
         } else if !isTimelineOpen() {
             timelineView?.viewModel.updateIndex(withIndex: index)
             timelineView?.viewModel.setIsOpen(isOpen: true)
-            self.timelineViewWindow?.toggleFullScreen(nil)
             timelineViewWindow?.makeKeyAndOrderFront(nil)
             DispatchQueue.main.async {
                 self.timelineViewWindow?.orderFrontRegardless() // Ensure it comes to the front

--- a/rem/remApp.swift
+++ b/rem/remApp.swift
@@ -664,7 +664,7 @@ func drawStatusBarIcon(rect: CGRect) -> Bool {
                 }
             })
             timelineView?.viewModel.updateIndex(withIndex: index)
-            
+
             timelineViewWindow?.contentView = NSHostingView(rootView: timelineView)
             timelineView?.viewModel.setIsOpen(isOpen: true)
             timelineViewWindow?.makeKeyAndOrderFront(nil)

--- a/rem/remApp.swift
+++ b/rem/remApp.swift
@@ -653,7 +653,6 @@ func drawStatusBarIcon(rect: CGRect) -> Bool {
                 backing: .buffered,
                 defer: false
             )
-            
             timelineViewWindow?.hasShadow = false
             timelineViewWindow?.level = .normal
 

--- a/rem/remApp.swift
+++ b/rem/remApp.swift
@@ -664,7 +664,6 @@ func drawStatusBarIcon(rect: CGRect) -> Bool {
                 }
             })
             timelineView?.viewModel.updateIndex(withIndex: index)
-            
             timelineViewWindow?.contentView = NSHostingView(rootView: timelineView)
             timelineView?.viewModel.setIsOpen(isOpen: true)
             timelineViewWindow?.makeKeyAndOrderFront(nil)

--- a/rem/remApp.swift
+++ b/rem/remApp.swift
@@ -664,18 +664,18 @@ func drawStatusBarIcon(rect: CGRect) -> Bool {
                 }
             })
             timelineView?.viewModel.updateIndex(withIndex: index)
-            timelineViewWindow?.toggleFullScreen(nil)
 
             timelineViewWindow?.contentView = NSHostingView(rootView: timelineView)
             timelineView?.viewModel.setIsOpen(isOpen: true)
+            self.timelineViewWindow?.toggleFullScreen(nil)
             timelineViewWindow?.makeKeyAndOrderFront(nil)
             DispatchQueue.main.async {
                 self.timelineViewWindow?.orderFrontRegardless() // Ensure it comes to the front
             }
         } else if !isTimelineOpen() {
             timelineView?.viewModel.updateIndex(withIndex: index)
-            timelineViewWindow?.toggleFullScreen(nil)
             timelineView?.viewModel.setIsOpen(isOpen: true)
+            self.timelineViewWindow?.toggleFullScreen(nil)
             timelineViewWindow?.makeKeyAndOrderFront(nil)
             DispatchQueue.main.async {
                 self.timelineViewWindow?.orderFrontRegardless() // Ensure it comes to the front

--- a/rem/remApp.swift
+++ b/rem/remApp.swift
@@ -664,6 +664,7 @@ func drawStatusBarIcon(rect: CGRect) -> Bool {
                 }
             })
             timelineView?.viewModel.updateIndex(withIndex: index)
+            
             timelineViewWindow?.contentView = NSHostingView(rootView: timelineView)
             timelineView?.viewModel.setIsOpen(isOpen: true)
             timelineViewWindow?.makeKeyAndOrderFront(nil)

--- a/rem/remApp.swift
+++ b/rem/remApp.swift
@@ -649,14 +649,14 @@ func drawStatusBarIcon(rect: CGRect) -> Bool {
             let screenRect = NSScreen.main?.frame ?? NSRect.zero
             timelineViewWindow = MainWindow(
                 contentRect: screenRect,
-                styleMask: [.borderless, .fullSizeContentView],
+                styleMask: [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView],
                 backing: .buffered,
                 defer: false
             )
             timelineViewWindow?.hasShadow = false
             timelineViewWindow?.level = .normal
 
-            timelineViewWindow?.collectionBehavior = [.fullScreenAuxiliary, .canJoinAllSpaces, .participatesInCycle]
+            timelineViewWindow?.collectionBehavior = [.fullScreenPrimary, .canJoinAllSpaces, .participatesInCycle]
             timelineViewWindow?.ignoresMouseEvents = false
             timelineView = TimelineView(viewModel: TimelineViewModel(), settingsManager: settingsManager, onClose: {
                 DispatchQueue.main.async { [weak self] in

--- a/rem/remApp.swift
+++ b/rem/remApp.swift
@@ -673,8 +673,8 @@ func drawStatusBarIcon(rect: CGRect) -> Bool {
                 self.timelineViewWindow?.orderFrontRegardless() // Ensure it comes to the front
             }
         } else if !isTimelineOpen() {
-            timelineViewWindow?.toggleFullScreen(nil)
             timelineView?.viewModel.updateIndex(withIndex: index)
+            timelineViewWindow?.toggleFullScreen(nil)
             timelineView?.viewModel.setIsOpen(isOpen: true)
             timelineViewWindow?.makeKeyAndOrderFront(nil)
             DispatchQueue.main.async {


### PR DESCRIPTION
Previously the method of having the timeline view go fullscreen caused external monitors to blackout (and just kinda freakout generally)

I tried to also add in seeing the mac menubar when the user scrolls up but instead an option to exit full screen is given.




https://github.com/jasonjmcghee/rem/assets/54302513/f29a2e8e-fabf-4520-935b-b50c60feb36b

