### PR TITLE
Convert frameId to chunksFramesIndex before passing from search to TL and fix search results missing frames with offset of 29

### DIFF
--- a/rem/DB.swift
+++ b/rem/DB.swift
@@ -253,6 +253,19 @@ class DatabaseManager {
         return nil
     }
     
+    func getChunksFramesIndex(frameId index: Int64) -> Int64? {
+        do {
+            let query = chunksFramesView.filter(frameId == index).limit(1)
+            if let frame = try db.pluck(query) {
+                return frame[chunksFramesIndex]
+            }
+        } catch {
+            return nil
+        }
+        
+        return nil
+    }
+    
     func getFrameByChunksFramesIndex(forIndex index: Int64) -> (offsetIndex: Int64, filePath: String)? {
         do {
             let query = chunksFramesView.filter(chunksFramesIndex == index).limit(1)

--- a/rem/Search.swift
+++ b/rem/Search.swift
@@ -424,7 +424,7 @@ struct ResultsView: View {
                 switch imageResult {
                 case .success(let requestedTime, let image, _):
                     if count < results.count {
-                        let offset = Int64(requestedTime.seconds * fps)
+                        let offset = Int64((requestedTime.seconds * Double(fps)).rounded())
                         if let id = offsetToId[offset] {
                             if let dataIndex = frameIdIndexLookup[id] {
                                 results[dataIndex].updateThumbnail(NSImage(cgImage: image, size: NSZeroSize))

--- a/rem/remApp.swift
+++ b/rem/remApp.swift
@@ -708,7 +708,12 @@ func drawStatusBarIcon(rect: CGRect) -> Bool {
     }
     
     func openFullView(atIndex index: Int64) {
-        showTimelineView(with: index)
+        // Needed since Search returns a frameId but Timeline runs on chunksFramesIndexs
+        if let chunksFramesIndex = DatabaseManager.shared.getChunksFramesIndex(frameId: index) {
+            showTimelineView(with: chunksFramesIndex)
+        } else {
+            print("No chunksFramesIndex found for frameId \(index)")
+        }
     }
     
     func closeSearchView() {

--- a/rem/remApp.swift
+++ b/rem/remApp.swift
@@ -708,7 +708,7 @@ func drawStatusBarIcon(rect: CGRect) -> Bool {
     }
     
     func openFullView(atIndex index: Int64) {
-        // Needed since Search returns a frameId but Timeline runs on chunksFramesIndexs
+        // Needed since Search returns a frameId but Timeline runs on chunksFramesIndexes
         if let chunksFramesIndex = DatabaseManager.shared.getChunksFramesIndex(frameId: index) {
             showTimelineView(with: chunksFramesIndex)
         } else {


### PR DESCRIPTION
In #90 a bug was introduced since Search is based off of indexes with the frames table, while the timeline now works on indexes within the chunksFramesView. Therefore, when a search thumbnail is clicked the frames index is passed, but the timeline treats it as a chunksFramesIndex.

This was fixed by converting the frameId to a chunksFramesIndex before passing to the showTimelineView() func. A solution converting the Search functionality to using chunksFramesIndexes was explored, but since all Database retrievals within Search already merge on the chunks table it was not necessary. As well, converting to chunksFramesIndexes would have inhibited the use of pagination.

I noticed that within search results, frames with an offset of 29 did not have thumbnails. I fixed this bug by rounding within the offset calculation while mapping retrieved thumbnails.