### PR TITLE
Active Display by Mouse Location

### DIFF
--- a/rem/SettingsManager.swift
+++ b/rem/SettingsManager.swift
@@ -16,6 +16,7 @@ struct AppSettings: Codable {
     var onlyOCRFrontmostWindow: Bool = true
     var fastOCR: Bool = true
     var startRememberingOnStartup: Bool = false
+    var recordWindowWithMouse: Bool = false
 }
 
 // The settings manager handles saving and loading the settings
@@ -64,6 +65,8 @@ struct SettingsView: View {
                     .onChange(of: settingsManager.settings.onlyOCRFrontmostWindow) { _ in settingsManager.saveSettings() }
                 Toggle("Use faster, but lower accuracy OCR (more efficient)", isOn: $settingsManager.settings.fastOCR)
                     .onChange(of: settingsManager.settings.fastOCR) { _ in settingsManager.saveSettings() }
+                Toggle("Always record window with mouse", isOn: $settingsManager.settings.recordWindowWithMouse)
+                    .onChange(of: settingsManager.settings.recordWindowWithMouse) { _ in settingsManager.saveSettings() }
             }
         }
         .padding()

--- a/rem/remApp.swift
+++ b/rem/remApp.swift
@@ -362,10 +362,6 @@ func drawStatusBarIcon(rect: CGRect) -> Bool {
                     }
                 }
     
-//                if let screenID = NSScreen.main?.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? NSNumber {
-//                    displayID = CGDirectDisplayID(screenID.uint32Value)
-//                    logger.debug("Display ID: \(displayID ?? 999)")
-//                }
                 guard displayID != nil else { return }
                 
                 guard let display = shareableContent.displays.first(where: { $0.displayID == displayID }) else { return }

--- a/rem/remApp.swift
+++ b/rem/remApp.swift
@@ -89,7 +89,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     
     private var lastImageData: Data? = nil
     private var lastActiveApplication: String? = nil
-    private var lastActiveDisplayID: UInt32? = nil
+    private var lastDisplayID: UInt32? = nil
     
     
     private var imageResizer = ImageResizer(
@@ -390,10 +390,10 @@ func drawStatusBarIcon(rect: CGRect) -> Bool {
                 }
                 
                 // Might as well only check if the applications are the same, otherwise obviously different
-                if activeApplicationName != lastActiveApplication || lastActiveDisplayID != displayID || displayImageChangedFromLast(imageData: imageData) {
+                if activeApplicationName != lastActiveApplication || lastDisplayID != displayID || displayImageChangedFromLast(imageData: imageData) {
                     lastImageData = imageData;
                     lastActiveApplication = activeApplicationName;
-                    lastActiveDisplayID = displayID;
+                    lastDisplayID = displayID;
                     
                     let frameId = DatabaseManager.shared.insertFrame(activeApplicationName: activeApplicationName)
                     


### PR DESCRIPTION
This PR is addressing https://github.com/jasonjmcghee/rem/issues/91

The issue was that when a window in in full screen mode on an external display`NSScreen.main` is set to 1 (which is the main monitor) even if the active application is on the external monitor. Since this was method used to determine which display to record, an external monitor in fullscreen mode was never able to be recorded.

I attempted to use the active window frame to identify the active display ID but things got strange with the returned frame dimensions, and I could not identify a consistent way to get the correct display ID. This got me concerned about the onlyOCRFrontmostWindow functionality as it utilizes the window.frame to determine the region to crop. Two weird things occurred: 
1) Sometimes the height of the frame would be a number below 100 despite the window being much larger (actually happened most when the window was fullscreen)
2) Moving the frame around and resizing it did not change the window.frame dimensions 😬

Also, since the window.frame will contain negative values when the window is on an external monitor, the cropImage functionality fails causing a fallback to full image OCR.

Sub ideal solution:
Use the mouse location to identify the active display.
Main considerations:
1) Now the active application stored is not necessarily the one in the given frame. This makes the searching by application less functional. Looking at rewind.ai's product, I noticed that the active application is not always the image being shown on the timeline, and I'm assuming this is the reason why.
2) To avoid cropping the wrong region when the active window in on the main monitor, but the active display is not the main monitor, cropping before OCR will only occur when the displayID is 1. Although not very clean, having the active window on an external monitor and the active display as the main monitor is handled already since cropImage will fail with the negative window frame values.

P.S. Maybe this is not an issue when there are no external monitors, but the funky window.frame results (even when the window was on the main display) sketched me out, so I will personally be turning off onlyOCRFrontmostWindow 🤷. Hopefully can find a good solution, but a small amount of research leads me to believe using the accessibility API may be the only robust option.