### PR TITLE
Store OCR Locations

### DIFF
--- a/rem/DB.swift
+++ b/rem/DB.swift
@@ -262,6 +262,22 @@ class DatabaseManager {
         try! db.run(insert)
     }
     
+    func insertTextsForFrames(entries: [(frameId: Int64, text: String, x: Double, y: Double, w: Double, h: Double)]){
+        try! db.transaction {
+            for entry in entries {
+                let insert = framesText.insert(
+                    self.frameId <- entry.frameId,
+                    self.text <- entry.text,
+                    self.x <- entry.x,
+                    self.y <- entry.y,
+                    self.w <- entry.w,
+                    self.h <- entry.h
+                )
+                try db.run(insert)
+            }
+        }
+    }
+    
     func insertAllTextForFrame(frameId: Int64, text: String) {
         let insert = allText.insert(self.frameId <- frameId, self.text <- text)
         try! db.run(insert)

--- a/rem/SettingsManager.swift
+++ b/rem/SettingsManager.swift
@@ -16,6 +16,7 @@ struct AppSettings: Codable {
     var onlyOCRFrontmostWindow: Bool = true
     var fastOCR: Bool = true
     var startRememberingOnStartup: Bool = false
+    var recordWindowWithMouse: Bool = false
 }
 
 // The settings manager handles saving and loading the settings
@@ -64,6 +65,8 @@ struct SettingsView: View {
                     .onChange(of: settingsManager.settings.onlyOCRFrontmostWindow) { _ in settingsManager.saveSettings() }
                 Toggle("Use faster, but lower accuracy OCR (more efficient)", isOn: $settingsManager.settings.fastOCR)
                     .onChange(of: settingsManager.settings.fastOCR) { _ in settingsManager.saveSettings() }
+                Toggle("Always record window with mouse", isOn: $settingsManager.settings.recordWindowWithMouse)
+                    .onChange(of: settingsManager.settings.recordWindowWithMouse) { _ in settingsManager.saveSettings() }
             }
         }
         .padding()

--- a/rem/remApp.swift
+++ b/rem/remApp.swift
@@ -642,19 +642,20 @@ func drawStatusBarIcon(rect: CGRect) -> Bool {
                     }
                     
                     let candidateConfidenceThreshold: Float = 0.35
-                    var texts = [String]()
+                    var textEntries = [(frameId: Int64, text: String, x: Double, y: Double, w: Double, h: Double)]()
                     for observation in observations {
                         if let candidate = observation.topCandidates(1).first, candidate.confidence > candidateConfidenceThreshold {
                             let string = candidate.string
                             let stringRange = string.startIndex..<string.endIndex
                             let box = try? candidate.boundingBox(for: stringRange)
                             let boundingBox = box?.boundingBox ?? .zero
-                            DatabaseManager.shared.insertTextForFrame(frameId: frameId, text: string, x: boundingBox.minX, y: boundingBox.minY,
-                                                                      w: boundingBox.width, h: boundingBox.height)
-                            texts.append(string)
+                            textEntries.append((frameId: frameId, text: string, x: boundingBox.minX, y: boundingBox.minY,
+                                                w: boundingBox.width, h: boundingBox.height))
                         }
                     }
+                    DatabaseManager.shared.insertTextsForFrames(entries: textEntries)
                     
+                    var texts = textEntries.map { $0.text }
                     if self.settingsManager.settings.saveEverythingCopiedToClipboard {
                         let newClipboardText = ClipboardManager.shared.getClipboardIfChanged() ?? ""
                         texts.append(newClipboardText)

--- a/rem/remApp.swift
+++ b/rem/remApp.swift
@@ -362,10 +362,6 @@ func drawStatusBarIcon(rect: CGRect) -> Bool {
                     }
                 }
     
-//                if let screenID = NSScreen.main?.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? NSNumber {
-//                    displayID = CGDirectDisplayID(screenID.uint32Value)
-//                    logger.debug("Display ID: \(displayID ?? 999)")
-//                }
                 guard displayID != nil else { return }
                 
                 guard let display = shareableContent.displays.first(where: { $0.displayID == displayID }) else { return }

--- a/rem/remApp.swift
+++ b/rem/remApp.swift
@@ -89,7 +89,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     
     private var lastImageData: Data? = nil
     private var lastActiveApplication: String? = nil
-    private var lastActiveDisplayID: UInt32? = nil
+    private var lastDisplayID: UInt32? = nil
     
     
     private var imageResizer = ImageResizer(
@@ -390,10 +390,10 @@ func drawStatusBarIcon(rect: CGRect) -> Bool {
                 }
                 
                 // Might as well only check if the applications are the same, otherwise obviously different
-                if activeApplicationName != lastActiveApplication || lastActiveDisplayID != displayID || displayImageChangedFromLast(imageData: imageData) {
+                if activeApplicationName != lastActiveApplication || lastDisplayID != displayID || displayImageChangedFromLast(imageData: imageData) {
                     lastImageData = imageData;
                     lastActiveApplication = activeApplicationName;
-                    lastActiveDisplayID = displayID;
+                    lastDisplayID = displayID;
                     
                     let frameId = DatabaseManager.shared.insertFrame(activeApplicationName: activeApplicationName)
                     


### PR DESCRIPTION
Addressing #87 

Previously all OCR results for a given frame were combined and stored as a single row in the allText Virtual Table. Now, the framesText table stores a row for each OCR result with columns (frame_id, text, x, y, w, h).

The main reason for this addition is the ability to now group texts into "paragraphs" for higher performance on more complex downstream tasks (i.e. RAG, etc...)

Considerations:
1) Now the OCR results are being stored in both the allText and framesText tables. The issue is replicating the search functionality with just the framesText will be less optimal since OCR result bounding boxes can be unpredictable and search results may not appear if the text is spread across multiple rows in the framesText table. One solution could be grouping the OCR results into "paragraphs" before entering into the framesText table, but I would like to avoid this since that functionality will be extremely unpredictable/ experimental and I'd rather keep the raw results. Any suggestions??
2) The x, y, w, h columns are currently the raw values of the returned bounding boxes which are actually values from 0-1 that represent the percentage of the frame. These could be converted to pixel values within the image by multiplying x and w by the image.width and y and h by the image.height. That might be a bit more intuitive for users but I'm pretty indifferent.
