### PR TITLE
retryScreenshot for more Robust screenshot loop

### DIFF
--- a/rem/DB.swift
+++ b/rem/DB.swift
@@ -59,8 +59,8 @@ class DatabaseManager {
             db = try! Connection("db.sqlite3")
         }
         
-        // 2 second busy timeout
-        db.busyTimeout = 2000
+        try! db.run("PRAGMA journal_mode = WAL")
+        try! db.run("PRAGMA synchronous = NORMAL")
         
         createTables()
         currentChunkId = getCurrentChunkId()

--- a/rem/DB.swift
+++ b/rem/DB.swift
@@ -59,6 +59,9 @@ class DatabaseManager {
             db = try! Connection("db.sqlite3")
         }
         
+        // 2 second busy timeout
+        db.busyTimeout = 2000
+        
         createTables()
         currentChunkId = getCurrentChunkId()
         lastFrameId = getLastFrameId()

--- a/rem/remApp.swift
+++ b/rem/remApp.swift
@@ -356,7 +356,7 @@ func drawStatusBarIcon(rect: CGRect) -> Bool {
                 self?.scheduleScreenshot(shareableContent: shareableContent)
             }
         } else {
-            stopScreenCapture()
+            disableRecording()
             screenshotRetries = 0
         }
     }

--- a/rem/remApp.swift
+++ b/rem/remApp.swift
@@ -90,6 +90,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private var lastImageData: Data? = nil
     private var lastActiveApplication: String? = nil
     private var lastDisplayID: UInt32? = nil
+    private var screenshotRetries: Int = 0
     
     
     private var imageResizer = ImageResizer(
@@ -347,11 +348,20 @@ func drawStatusBarIcon(rect: CGRect) -> Bool {
         }
         return false
     }
+    
+    private func retryScreenshot(shareableContent: SCShareableContent) {
+        if screenshotRetries < 3 {
+            screenshotRetries += 1
+            screenshotQueue.asyncAfter(deadline: .now() + 2) { [weak self] in
+                self?.scheduleScreenshot(shareableContent: shareableContent)
+            }
+        }
+    }
 
     private func scheduleScreenshot(shareableContent: SCShareableContent) {
         Task {
             do {
-                guard isCapturing == .recording else { 
+                guard isCapturing == .recording else {
                     logger.debug("Stopped Recording")
                     return }
                 
@@ -372,14 +382,18 @@ func drawStatusBarIcon(rect: CGRect) -> Bool {
                         logger.debug("Active Display ID: \(displayID ?? 999)")
                     }
                 }
-
-                guard displayID != nil else { 
-                    logger.debug("DisplayID is nil")
-                    return }
                 
-                guard let display = shareableContent.displays.first(where: { $0.displayID == displayID }) else { 
+                guard displayID != nil else {
+                    logger.debug("DisplayID is nil")
+                    retryScreenshot(shareableContent: shareableContent)
+                    return
+                }
+                
+                guard let display = shareableContent.displays.first(where: { $0.displayID == displayID }) else {
                     logger.debug("Display could not be retrieved")
-                    return }
+                    retryScreenshot(shareableContent: shareableContent)
+                    return
+                }
                 
                 let activeApplicationName = NSWorkspace.shared.frontmostApplication?.localizedName
                 
@@ -435,6 +449,7 @@ func drawStatusBarIcon(rect: CGRect) -> Bool {
                 logger.error("Error taking screenshot: \(error)")
             }
             
+            screenshotRetries = 0
             screenshotQueue.asyncAfter(deadline: .now() + 2) { [weak self] in
                 self?.scheduleScreenshot(shareableContent: shareableContent)
             }

--- a/rem/remApp.swift
+++ b/rem/remApp.swift
@@ -355,6 +355,9 @@ func drawStatusBarIcon(rect: CGRect) -> Bool {
             screenshotQueue.asyncAfter(deadline: .now() + 2) { [weak self] in
                 self?.scheduleScreenshot(shareableContent: shareableContent)
             }
+        } else {
+            stopScreenCapture()
+            screenshotRetries = 0
         }
     }
 


### PR DESCRIPTION
Now when the retrieval of the DisplayID or Display fails, the screenshot process is reattempted up to 3 times in a row.

This should help prevent silent exiting of the screenshot loop.