### PR TITLE
startScreenCapture in loop

### DIFF
--- a/rem/remApp.swift
+++ b/rem/remApp.swift
@@ -353,6 +353,7 @@ func drawStatusBarIcon(rect: CGRect) -> Bool {
         if screenCaptureRetries < 3 {
             screenCaptureRetries += 1
             Task {
+                try await Task.sleep(nanoseconds: 2_000_000_000)
                 await startScreenCapture()
             }
         } else {

--- a/rem/remApp.swift
+++ b/rem/remApp.swift
@@ -324,8 +324,8 @@ func drawStatusBarIcon(rect: CGRect) -> Bool {
             let shareableContent = try await SCShareableContent.excludingDesktopWindows(false, onScreenWindowsOnly: false)
 
             setupMenu()
-            Task {
-                await startScreenCapture()
+            screenshotQueue.async { [weak self] in
+                self?.scheduleScreenshot(shareableContent: shareableContent)
             }
         } catch {
             logger.error("Error starting screen capture: \(error.localizedDescription)")
@@ -352,8 +352,8 @@ func drawStatusBarIcon(rect: CGRect) -> Bool {
     private func retryScreenshot(shareableContent: SCShareableContent) {
         if screenshotRetries < 3 {
             screenshotRetries += 1
-            screenshotQueue.asyncAfter(deadline: .now() + 2) { [weak self] in
-                self?.scheduleScreenshot(shareableContent: shareableContent)
+            Task {
+                await startScreenCapture()
             }
         } else {
             disableRecording()

--- a/rem/remApp.swift
+++ b/rem/remApp.swift
@@ -324,8 +324,8 @@ func drawStatusBarIcon(rect: CGRect) -> Bool {
             let shareableContent = try await SCShareableContent.excludingDesktopWindows(false, onScreenWindowsOnly: false)
 
             setupMenu()
-            screenshotQueue.async { [weak self] in
-                self?.scheduleScreenshot(shareableContent: shareableContent)
+            Task {
+                await startScreenCapture()
             }
         } catch {
             logger.error("Error starting screen capture: \(error.localizedDescription)")

--- a/rem/remApp.swift
+++ b/rem/remApp.swift
@@ -90,7 +90,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private var lastImageData: Data? = nil
     private var lastActiveApplication: String? = nil
     private var lastDisplayID: UInt32? = nil
-    private var screenshotRetries: Int = 0
+    private var screenCaptureRetries: Int = 0
     
     
     private var imageResizer = ImageResizer(
@@ -349,15 +349,15 @@ func drawStatusBarIcon(rect: CGRect) -> Bool {
         return false
     }
     
-    private func retryScreenshot(shareableContent: SCShareableContent) {
-        if screenshotRetries < 3 {
-            screenshotRetries += 1
+    private func retryScreenCapture() {
+        if screenCaptureRetries < 3 {
+            screenCaptureRetries += 1
             Task {
                 await startScreenCapture()
             }
         } else {
             disableRecording()
-            screenshotRetries = 0
+            screenCaptureRetries = 0
         }
     }
 
@@ -388,13 +388,13 @@ func drawStatusBarIcon(rect: CGRect) -> Bool {
                 
                 guard displayID != nil else {
                     logger.debug("DisplayID is nil")
-                    retryScreenshot(shareableContent: shareableContent)
+                    retryScreenCapture()
                     return
                 }
                 
                 guard let display = shareableContent.displays.first(where: { $0.displayID == displayID }) else {
                     logger.debug("Display could not be retrieved")
-                    retryScreenshot(shareableContent: shareableContent)
+                    retryScreenCapture()
                     return
                 }
                 
@@ -452,7 +452,7 @@ func drawStatusBarIcon(rect: CGRect) -> Bool {
                 logger.error("Error taking screenshot: \(error)")
             }
             
-            screenshotRetries = 0
+            screenCaptureRetries = 0
             screenshotQueue.asyncAfter(deadline: .now() + 2) { [weak self] in
                 self?.scheduleScreenshot(shareableContent: shareableContent)
             }


### PR DESCRIPTION
Change retryScreenshot() to retryScreenCapture():
Instead of trying to retake the screenshot with the same shareableContent var, startScreenCapture() is run to ensure proper monitor capturing if a monitor is added or removed after the first call to startScreenCapture().